### PR TITLE
PARQUETのbq loadオプションの設定ミスを修正

### DIFF
--- a/.github/workflows/corporate_numbers.yml
+++ b/.github/workflows/corporate_numbers.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: google-github-actions/setup-gcloud@master
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
-      - run: bq load --source_format=PARQUET --skip_leading_rows=1 corporate_numbers.corporate_numbers outputs/corporate_numbers.parquet corporate_numbers/corporate_numbers_schema.json
+      - run: bq load --source_format=PARQUET corporate_numbers.corporate_numbers outputs/corporate_numbers.parquet corporate_numbers/corporate_numbers_schema.json
       - name: Instal IBM Cloud CLI
         run: curl -sL https://raw.githubusercontent.com/IBM-Cloud/ibm-cloud-developer-tools/master/linux-installer/idt-installer | bash
       - run: ibmcloud login --apikey "$IBM_CLOUD_API_KEY" -r ""


### PR DESCRIPTION
#16 の修正。

> BigQuery error in load operation: Only CSV imports may specify leading rows to skip. 

https://github.com/bqfun/jpdata/runs/2254644700