### PR TITLE
外国製造業者認定・登録リストのファイルが見つからない問題を修正

### DIFF
--- a/accredited_foreign_manufacturers/app.py
+++ b/accredited_foreign_manufacturers/app.py
@@ -100,7 +100,7 @@ def main():
         )
         unzip(os.path.join(tmpdirname, "accredited_foreign_manufacturers.zip"))
         xlsx_file = find_file(
-            os.path.join(tmpdirname, "外国製造業者認定・登録リスト_*.xlsx")
+            os.path.join(tmpdirname, "**", "外国製造業者認定・登録リスト_*.xlsx")
         )
         extract_csv(
             xlsx_file,


### PR DESCRIPTION
外国製造業者認定・登録リストのzipがフォルダ込みで圧縮されていたため失敗した。
フォルダ深くに入っていても良いように修正。

https://github.com/bqfun/jpdata/runs/2283374693

> Traceback (most recent call last):
  File "/app.py", line 112, in <module>
    main()
  File "/app.py", line 103, in main
    os.path.join(tmpdirname, "外国製造業者認定・登録リスト_*.xlsx")
  File "/app.py", line 42, in find_file
    return glob.glob(file)[0]
IndexError: list index out of range