### PR TITLE
出生数：厚生労働省『人口動態調査』maven working-directoryの設定

### DIFF
--- a/.github/workflows/number_of_births.yml
+++ b/.github/workflows/number_of_births.yml
@@ -25,6 +25,7 @@ jobs:
       - run: |
           mvn compile com.google.cloud.tools:jib-maven-plugin:2.8.0:build \
                   -Dimage=ghcr.io/bqfun/number_of_births
+        working-directory: number_of_births
       - uses: ./number_of_births
         with:
           destination: /home/runner/work/jpdata/jpdata/outputs


### PR DESCRIPTION
https://github.com/bqfun/jpdata/runs/2324919354

> Error:  The goal you specified requires a project to execute but there is no POM in this directory (/home/runner/work/jpdata/jpdata). Please verify you invoked Maven from the correct directory. -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MissingProjectException
Error: Process completed with exit code 1.