### PR TITLE
accredited_foreign_manufacturersのglob.globがファイル圧縮方式揺れに対応できていなかった不具合を修正

### DIFF
--- a/accredited_foreign_manufacturers/app.py
+++ b/accredited_foreign_manufacturers/app.py
@@ -39,7 +39,7 @@ def unzip(file: str):
 
 
 def find_file(file):
-    return glob.glob(file)[0]
+    return next(glob.iglob(file, recursive=True), None)
 
 
 def extract_csv(xlsx_file: str, file: str):


### PR DESCRIPTION
glob.globは**を使うだけでは、再帰してくれないので、recursiveを使うように。
ファイル圧縮時に、フォルダが入ってたり入ってなかったりするので再帰で対応する。

ついでにnextを使って、対象がない時find_file関数が落ちないように。